### PR TITLE
Allow invokation of polymorphic operations

### DIFF
--- a/mbeanz/mbeanz
+++ b/mbeanz/mbeanz
@@ -61,18 +61,17 @@ def invoke_operation(mbean, operation, arguments):
     response = requests.get(api_url + '/invoke/' + operation, params = query_parameters)
     return response.json()
 
-def main():
+if __name__ == "__main__":
     mbean, operation = select_mbean()
     description, signature = describe_mbean(mbean, operation)
-    print(colors.BOLD + description + colors.ENDC, end = '\n')
-    print('')
+    print(colors.BOLD + '\n' + description + colors.ENDC, end = '\n\n')
     arguments = get_arguments(signature)
     result = invoke_operation(mbean, operation, arguments)
     if (result):
         if ('error' in result):
-            print(colors.FAIL + result['error']['class'], end = '\n')
-            print(result['error']['message'] + colors.ENDC, end = '\n')
+            print()
+            print(colors.FAIL + result['error']['class'])
+            print(result['error']['message'] + colors.ENDC, end = '\n\n')
         else:
-            print(result['result'])
-
-main()
+            print()
+            print(result['result'], end = '\n\n')

--- a/mbeanz/mbeanz
+++ b/mbeanz/mbeanz
@@ -17,28 +17,47 @@ def select_mbean():
     mbean_operation = fzf.communicate(mbeans)[0].rstrip('\n').split(' ')
     return tuple(mbean_operation)
 
+def get_signature_string(index, description):
+    signature = description['signature']
+    params = [parameter['name'] + ' (' + parameter['type'] + ')' for parameter in signature]
+    return str(index) + ' ' + str.join(', ', params)
+
+def choose_signature(descriptions):
+    strings = [get_signature_string(i, descr) for i, descr in enumerate(descriptions)]
+    lines = str.join('\n', strings)
+    fzf = subprocess32.Popen('fzf', stdin = subprocess32.PIPE, stdout = subprocess32.PIPE)
+    index = fzf.communicate(lines)[0].split(' ')[0]
+    chosen = descriptions[int(index)]
+    return tuple([chosen['description'], chosen['signature']])
+
 def describe_mbean(mbean, operation):
-    mbean_info = requests.get(api_url + '/describe/' + operation, params = {'bean': mbean}).json()
-    description = mbean_info['description']
-    parameters = mbean_info['parameters']
-    return tuple([description, parameters])
+    mbean_infos = requests.get(api_url + '/describe/' + operation, params = {'bean': mbean}).json()
+    length = len(mbean_infos)
+    if (length == 1):
+        only_operation = mbean_infos[0]
+        return tuple([only_operation['description'], only_operation['signature']])
+    if (length >= 2):
+        return choose_signature(mbean_infos)
 
 def get_arguments(signature):
     arguments = []
     for parameter in signature:
-        print(parameter['name'] + ' (' + parameter['description'] + ')')
-        arguments.append(str(raw_input(parameter['type'] + ': ')))
+        print(parameter['description'])
+        user_input = raw_input(parameter['name'] + ' (' + parameter['type'] + '): ')
+        arguments.append(tuple([parameter['type'], user_input]))
     return arguments
 
 def invoke_operation(mbean, operation, arguments):
-    query_parameters = {'bean': mbean, 'args': arguments}
+    types = [arg[0] for arg in arguments]
+    values = [arg[1] for arg in arguments]
+    query_parameters = {'bean': mbean, 'args': values, 'types': types}
     response = requests.get(api_url + '/invoke/' + operation, params = query_parameters)
     print(response.json()['result'])
 
 def main():
     mbean, operation = select_mbean()
     description, signature = describe_mbean(mbean, operation)
-    print(description, end='\n')
+    print(description)
     arguments = get_arguments(signature)
     invoke_operation(mbean, operation, arguments)
 

--- a/mbeanz/mbeanz
+++ b/mbeanz/mbeanz
@@ -1,10 +1,17 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+import json
 import requests
 import subprocess32
 
 api_url = 'http://localhost:7999'
+
+class colors:
+    OKGREEN = '\033[92m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
 
 def get_mbeans():
     response = requests.get(api_url + '/list')
@@ -42,7 +49,7 @@ def describe_mbean(mbean, operation):
 def get_arguments(signature):
     arguments = []
     for parameter in signature:
-        print(parameter['description'])
+        print(colors.BOLD + parameter['description'] + colors.ENDC, end = '\n')
         user_input = raw_input(parameter['name'] + ' (' + parameter['type'] + '): ')
         arguments.append(tuple([parameter['type'], user_input]))
     return arguments
@@ -52,13 +59,25 @@ def invoke_operation(mbean, operation, arguments):
     values = [arg[1] for arg in arguments]
     query_parameters = {'bean': mbean, 'args': values, 'types': types}
     response = requests.get(api_url + '/invoke/' + operation, params = query_parameters)
-    print(response.json()['result'])
+    return response.json()['result']
 
 def main():
     mbean, operation = select_mbean()
     description, signature = describe_mbean(mbean, operation)
-    print(description)
+    print(colors.BOLD + description + colors.ENDC, end = '\n')
+    print('')
     arguments = get_arguments(signature)
-    invoke_operation(mbean, operation, arguments)
+    result = invoke_operation(mbean, operation, arguments)
+    if (result):
+        try:
+            iterator = iter(result)
+        except TypeError:
+            print(colors.OKGREEN + str(result) + colors.ENDC)
+        else:
+            if ('error' in result):
+                print(colors.FAIL + result['error']['class'], end = '\n')
+                print(result['error']['message'] + colors.ENDC, end = '\n')
+            else:
+                print(colors.OKGREEN + result + colors.ENDC)
 
 main()

--- a/mbeanz/mbeanz
+++ b/mbeanz/mbeanz
@@ -59,7 +59,7 @@ def invoke_operation(mbean, operation, arguments):
     values = [arg[1] for arg in arguments]
     query_parameters = {'bean': mbean, 'args': values, 'types': types}
     response = requests.get(api_url + '/invoke/' + operation, params = query_parameters)
-    return response.json()['result']
+    return response.json()
 
 def main():
     mbean, operation = select_mbean()
@@ -69,15 +69,10 @@ def main():
     arguments = get_arguments(signature)
     result = invoke_operation(mbean, operation, arguments)
     if (result):
-        try:
-            iterator = iter(result)
-        except TypeError:
-            print(colors.OKGREEN + str(result) + colors.ENDC)
+        if ('error' in result):
+            print(colors.FAIL + result['error']['class'], end = '\n')
+            print(result['error']['message'] + colors.ENDC, end = '\n')
         else:
-            if ('error' in result):
-                print(colors.FAIL + result['error']['class'], end = '\n')
-                print(result['error']['message'] + colors.ENDC, end = '\n')
-            else:
-                print(colors.OKGREEN + result + colors.ENDC)
+            print(result['result'])
 
 main()

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [ring/ring-defaults "0.1.2"]
                  [ring/ring-json "0.4.0"]
                  [org.clojure/data.json "0.2.6"]
+                 [clj-stacktrace "0.2.8"]
                  [environ "1.0.1"]]
   :plugins [[lein-ring "0.8.13"]
             [jonase/eastwood "0.2.1"]

--- a/src/mbeanz/core.clj
+++ b/src/mbeanz/core.clj
@@ -14,38 +14,35 @@
 (defn list-beans [object-name-pattern]
   (->> (jmx/mbean-names object-name-pattern)
        (sort)
-       (map (comp get-identifiers #(list % (jmx/operation-names %))))
+       (map (comp get-identifiers
+                  #(list % (map first (partition-by identity (jmx/operation-names %))))))
        (flatten)))
 
 (defn- get-operation-info [bean-name operation]
-  (->> (jmx/operations bean-name)
-       (filter #(= (-> % .getName keyword) operation))
-       (first)))
-
-(defn get-params [bean-name operation]
-  (->> (get-operation-info bean-name operation)
-       (.getSignature)
-       (map #(hash-map :name (.getName %) :description (.getDescription %) :type (.getType %)))))
+  (filter #(= (-> % .getName keyword) operation) (jmx/operations bean-name)))
 
 (defn cast-type [[type-name arg]]
   (match [type-name]
-         [:int] (int (Integer/parseInt arg))
-         [:long] (long (Long/parseLong arg))
-         [:boolean] (boolean (Boolean/parseBoolean arg))
-         [:java.lang.String] arg
+         ["int"] (int (Integer/parseInt arg))
+         ["long"] (long (Long/parseLong arg))
+         ["boolean"] (boolean (Boolean/parseBoolean arg))
+         ["java.lang.String"] arg
          :else (throw (IllegalArgumentException. (str "Unsupported argument type " type-name)))))
 
-(defn get-typed-args [bean-name operation & args]
-  (let [types (map (comp keyword :type) (get-params bean-name operation))]
-    (map list types args)))
-
-(defn invoke [bean-name operation & args]
-  (if (seq? args)
-    (let [typed-args (apply get-typed-args bean-name operation args)
-          types (map (comp stringify first) typed-args)
+(defn invoke [bean-name operation & typed-args]
+  (if (seq? typed-args)
+    (let [types (map first typed-args)
           values (map cast-type typed-args)]
       (apply jmx/invoke-signature bean-name operation types values))
     (jmx/invoke bean-name operation)))
 
+(defn- get-signature-descriptions [operation]
+  {:name (.getName operation)
+   :description (.getDescription operation)
+   :signature (map #(hash-map :name (.getName %)
+                              :description (.getDescription %)
+                              :type (.getType %))
+                   (.getSignature operation))})
+
 (defn describe [bean-name operation]
-  (.getDescription (get-operation-info bean-name operation)))
+  (map get-signature-descriptions (get-operation-info bean-name operation)))

--- a/src/mbeanz/handler.clj
+++ b/src/mbeanz/handler.clj
@@ -8,7 +8,8 @@
             [mbeanz.common :refer :all]
             [environ.core :refer [env]]
             [clojure.java.jmx :as jmx])
-  (:use [org.httpkit.server :only [run-server]])
+  (:use [org.httpkit.server :only [run-server]]
+        [clj-stacktrace.core :only [parse-exception]])
   (:import java.lang.management.ManagementFactory))
 
 (def object-pattern (delay (or (env :mbeanz-object-pattern) "*:*")))
@@ -27,15 +28,22 @@
             op (keyword operation)]
         {:body (doall (describe mbean op))}))))
 
+(defn- try-invoke [mbean operation args types]
+  (try
+    (if (string? args)
+      (invoke mbean (keyword operation) (list types args))
+      (apply invoke mbean (keyword operation) (map list types args)))
+    (catch Exception exception
+      (let [{:keys [message class]} (parse-exception exception)]
+        {:error {:class (str class) :message message}}))))
+
 (defn- handle-invoke [operation]
   (fn [request]
     (jmx/with-connection {:host @jmx-remote-host :port @jmx-remote-port}
       (let [mbean (get-in request [:params :bean])
             args (get-in request [:params :args])
             types (get-in request [:params :types])]
-        (if (string? args)
-          {:body {:result (invoke mbean (keyword operation) (list types args))}}
-          {:body {:result (apply invoke mbean (keyword operation) (map list types args))}})))))
+        {:body {:result (try-invoke mbean operation args types)}}))))
 
 (defn- handle-list-beans []
   (fn [request]

--- a/src/mbeanz/handler.clj
+++ b/src/mbeanz/handler.clj
@@ -25,17 +25,17 @@
     (jmx/with-connection {:host @jmx-remote-host :port @jmx-remote-port}
       (let [mbean (get-in request [:params :bean])
             op (keyword operation)]
-        {:body (hash-map :description (doall (describe mbean op))
-                         :parameters (doall (get-params mbean op)))}))))
+        {:body (doall (describe mbean op))}))))
 
 (defn- handle-invoke [operation]
   (fn [request]
     (jmx/with-connection {:host @jmx-remote-host :port @jmx-remote-port}
       (let [mbean (get-in request [:params :bean])
-            args (get-in request [:params :args])]
+            args (get-in request [:params :args])
+            types (get-in request [:params :types])]
         (if (string? args)
-          {:body {:result (invoke mbean (keyword operation) args)}}
-          {:body {:result (apply invoke mbean (keyword operation) args)}})))))
+          {:body {:result (invoke mbean (keyword operation) (list types args))}}
+          {:body {:result (apply invoke mbean (keyword operation) (map list types args))}})))))
 
 (defn- handle-list-beans []
   (fn [request]

--- a/src/mbeanz/handler.clj
+++ b/src/mbeanz/handler.clj
@@ -26,13 +26,13 @@
     (jmx/with-connection {:host @jmx-remote-host :port @jmx-remote-port}
       (let [mbean (get-in request [:params :bean])
             op (keyword operation)]
-        {:body (doall (describe mbean op))}))))
+        (doall (describe mbean op))))))
 
 (defn- try-invoke [mbean operation args types]
   (try
     (if (string? args)
-      (invoke mbean (keyword operation) (list types args))
-      (apply invoke mbean (keyword operation) (map list types args)))
+      {:result (invoke mbean (keyword operation) (list types args))}
+      {:result (apply invoke mbean (keyword operation) (map list types args))})
     (catch Exception exception
       (let [{:keys [message class]} (parse-exception exception)]
         {:error {:class (str class) :message message}}))))
@@ -43,7 +43,7 @@
       (let [mbean (get-in request [:params :bean])
             args (get-in request [:params :args])
             types (get-in request [:params :types])]
-        {:body {:result (try-invoke mbean operation args types)}}))))
+        {:body (try-invoke mbean operation args types)}))))
 
 (defn- handle-list-beans []
   (fn [request]


### PR DESCRIPTION
If there is more than one signature for an operation the user is
prompted to choose the desired one.
The API now expects to receive not only the values of arguments in the
/invoke call, but also the types.
